### PR TITLE
Add initial bash completion support

### DIFF
--- a/completion/bash/pkgdev
+++ b/completion/bash/pkgdev
@@ -1,0 +1,136 @@
+# bash completion for pkgdev
+
+_pkgdev() {
+    local i=1 cmd cur prev words cword split
+    _init_completion || return
+
+    local GLOBAL_COMMANDS="
+        commit
+        manifest
+        mask
+        push
+        -v --version
+    "
+
+    local GLOBAL_OPTIONS="
+        --help
+        --debug
+        --quiet
+        --verbose
+        --color
+    "
+
+    local BOOLEAN_OPTIONS="
+        true
+        false
+    "
+
+    local COMMIT_OPTIONS="
+        -b --bug
+        -c --closes
+        -T --tag
+        -n --dry-run
+        -s --scan
+        -A --ask
+        --mangle
+        -m --message
+        -M --message-template
+        -u --update
+        -a --all
+    "
+
+    local MANIFEST_OPTIONS="
+        -f --force
+        -m --mirrors
+        -d --distdir
+    "
+
+    local MASK_OPTIONS="
+        -r --rites
+    "
+
+    local PUSH_OPTIONS="
+        -A --ask
+        -n --dry-run
+    "
+
+    _list_repo_atoms() {
+        builtin cd "$(git rev-parse --show-toplevel)" || return
+        if [[ $cur == */* ]]; then
+            compgen -W "$(compgen -G "${cur}*" )" -- "${cur}"
+        else
+            compgen -W "$(compgen -G "${cur}*" -S / )" -- "${cur}"
+        fi
+    }
+
+    if [[ ${prev} = "--color" ]]; then
+        COMPREPLY=($(compgen -W "${BOOLEAN_OPTIONS}" -- "${cur}"))
+        return
+    fi
+    COMPREPLY=($(compgen -W "${GLOBAL_OPTIONS}" -- "${cur}"))
+
+    # find the subcommand
+    while [[ "${i}" -lt "${COMP_CWORD}" ]]; do
+        local s="${COMP_WORDS[i]}"
+        case "${s}" in
+            -*) ;;
+            *)
+                cmd="${s}"
+                break
+                ;;
+        esac
+        ((i++))
+    done
+
+    if [[ "${i}" -eq "${COMP_CWORD}" ]]; then
+        COMPREPLY+=($(compgen -W "${GLOBAL_COMMANDS}" -- "${cur}"))
+        return
+    fi
+
+    case "${cmd}" in
+        commit)
+            case "${prev}" in
+                -[bcTm] | --bug | --closes | --tag | --message)
+                    COMPREPLY=()
+                    ;;
+                -M | --message-template)
+                    COMPREPLY=($(compgen -f -- "${cur}"))
+                    ;;
+                -s | --scan | --mangle)
+                    COMPREPLY=($(compgen -W "${BOOLEAN_OPTIONS}" -- "${cur}"))
+                    ;;
+                *)
+                    COMPREPLY+=($(compgen -W "${COMMIT_OPTIONS}" -- "${cur}"))
+                    ;;
+            esac
+            ;;
+        manifest)
+            case "${prev}" in
+                -d | --distdir)
+                    COMPREPLY=($(compgen -d -- "${cur}"))
+                    ;;
+                *)
+                    COMPREPLY+=($(compgen -W "${MANIFEST_OPTIONS}" -- "${cur}"))
+                    COMPREPLY+=($(_list_repo_atoms))
+                    ;;
+            esac
+            ;;
+        mask)
+            case "${prev}" in
+                -r | --rites)
+                    COMPREPLY=()
+                    ;;
+                *)
+                    COMPREPLY+=($(compgen -W "${MASK_OPTIONS}" -- "${cur}"))
+                    COMPREPLY+=($(_list_repo_atoms))
+                    ;;
+            esac
+            ;;
+        push)
+            COMPREPLY+=($(compgen -W "${PUSH_OPTIONS}" -- "${cur}"))
+            ;;
+    esac
+}
+complete -F _pkgdev pkgdev
+
+# vim: set ft=sh sw=4 et sts=4 :

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ setup(**dict(
     description='collection of tools for Gentoo development',
     url='https://github.com/pkgcore/pkgdev',
     data_files=list(chain(
+        pkgdist.data_mapping('share/bash-completion/completions', 'completion/bash'),
         pkgdist.data_mapping('share/zsh/site-functions', 'completion/zsh'),
     )),
     classifiers=[


### PR DESCRIPTION
I really like the new `pkgdev` utility, but the bash completion was very missing for me (as here #31).

Some notes about this addition:

- This is my first pull request to core Gentoo projects. If I missed something, please inform me and I will happily comply.
- I used my preferred bash style, but it might not confirm Gentoo's one. Please check the style.
- I have done quite simple completion: supporting the 4 subcommands, the base options, and all options which are shown in the `pkgdev * --help`.
- The completion suggests only long options (in my idea the short one are confusing to suggest, and also I saw that `emerge` doesn't suggest short opts also).
- For the `--bug`, `--closes` and etc I just disabled for one argument the completion (I have no idea what completion do here).

**Serious bug!**
I tried to add the auto installing of the bash completion in `setup.py`, in the `data_files`, but it failed for me. I guess it is quite easy, so I hope you can help me here.

If this PR is successful, I will gladly add bash completion support to other Gentoo projects based on this experience.

Signed-off-by: Zamarin Arthur <arthurzam@gmail.com>