### PR TITLE
pkgdev commit: turn copyright headers into date range when appropriate

### DIFF
--- a/src/pkgdev/mangle.py
+++ b/src/pkgdev/mangle.py
@@ -139,6 +139,12 @@ class GentooMangler(Mangler):
         """Fix copyright headers and dates."""
         lines = change.data.splitlines()
         if mo := copyright_regex.match(lines[0]):
-            lines[0] = re.sub(mo.group('end'), self._current_year, lines[0])
+            groups = mo.groupdict()
+            if groups['begin'] is None and groups['date'] != self._current_year:
+                # use old copyright date as the start of date range
+                date_range = f"{groups['date']}-{self._current_year}"
+                lines[0] = re.sub(groups['date'], date_range, lines[0])
+            else:
+                lines[0] = re.sub(mo.group('end'), self._current_year, lines[0])
             lines[0] = re.sub('Gentoo Foundation', 'Gentoo Authors', lines[0])
         return change.update('\n'.join(lines) + '\n')

--- a/tests/scripts/test_pkgdev_commit.py
+++ b/tests/scripts/test_pkgdev_commit.py
@@ -806,6 +806,7 @@ class TestPkgdevCommit:
                 lines = f.read().splitlines()
                 mo = copyright_regex.match(lines[0])
                 assert mo.group('end') == str(datetime.today().year)
+                assert mo.group('begin') == years[:4] + '-'
                 assert mo.group('holder') == 'Gentoo Authors'
 
     def test_scan(self, capsys, repo, make_git_repo):


### PR DESCRIPTION
In commit 303e3bde8a1d273b85395541a7f266d7e4f8a6c0 the behaviour of
"pkgdev commit" was modified to turn single copyright year lines into
year ranges, but the following commit
51c0f9a8ba88b776551057f08a1dc0278d4b1eb3 reverted that behaviour.

This is a simplified version of the date handling where a single year is
turned into a year range when the given year is not the current year.
This mirrors the behaviour of "repoman commit"

Fixes: https://bugs.gentoo.org/835333
Signed-off-by: Thomas Bracht Laumann Jespersen <t@laumann.xyz>