### PR TITLE
Improve commit message for new package import

### DIFF
--- a/src/pkgdev/scripts/pkgdev_commit.py
+++ b/src/pkgdev/scripts/pkgdev_commit.py
@@ -317,7 +317,10 @@ class PkgSummary(ChangeSummary):
     def add(self):
         """Generate summaries for add actions."""
         if len(self.existing) == len(self.changes):
-            return 'initial import'
+            msg = f"new package, add {', '.join(self.versions)}"
+            if len(self.versions) == 1 or len(msg) <= 50:
+                return msg
+            return 'new package'
         elif not self.revbump:
             msg = f"add {', '.join(self.versions)}"
             if len(self.versions) == 1 or len(msg) <= 50:

--- a/tests/scripts/test_pkgdev_commit.py
+++ b/tests/scripts/test_pkgdev_commit.py
@@ -425,7 +425,12 @@ class TestPkgdevCommit:
 
         # initial package import
         repo.create_ebuild('cat/newpkg-0')
-        assert commit() == 'cat/newpkg: initial import'
+        assert commit() == 'cat/newpkg: new package, add 0'
+
+        # initial package import, overflowed title truncated
+        for i in range(10):
+            repo.create_ebuild(f'cat/newpkg2-{i}.0.0')
+        assert commit() == 'cat/newpkg2: new package'
 
         # single addition
         repo.create_ebuild('cat/pkg-1')


### PR DESCRIPTION
Instead of plain `initial import` default automatic commit message when adding new packages to tree, it would include the added version, to look like: `new package, add 1.8.0`.