### PR TITLE
Add metadata.xml tabbed indent mangler

### DIFF
--- a/src/pkgdev/mangle.py
+++ b/src/pkgdev/mangle.py
@@ -85,6 +85,17 @@ class Mangler:
                 break
         return change.update('\n'.join(lines) + '\n')
 
+    @mangle('metadata.xml')
+    def _metadata(self, change):
+        """Format metadata.xml file."""
+        if not change.path.endswith('/metadata.xml'):
+            return change
+        lines = change.data.splitlines()
+        from lxml import etree
+        root = etree.XML(change.data.encode('utf8'))
+        etree.indent(root, space="\t")
+        return change.update('\n'.join(lines[:2]) + '\n' + etree.tostring(root, encoding=str))
+
     def _kill_pipe(self, *args, error=None):
         """Handle terminating the mangling process group."""
         if self._runner.is_alive():


### PR DESCRIPTION
Currently, we have in tree misformatted `metadata.xml` files with wrong indent at all.
On that front, we also have inconsistent indent for `metadata.xml`: some use 2 spaces, some use 4 spaces, and most use tabs. Speaking with QA team, I was informed that there was a try to enforce a standard indent in tree, which has failed.

In this PR, I want to add a XML formatter (for `metadata.xml` files only) that correctly indents the file, and uses tabs for indent.

As this change might be controversial, it will be given time for discussion.

----

**TODO:** Test and show diff for best review:

- [ ] The effect on long descriptions and such. Maybe to not touch the indent? Maybe only the starting indent?
- [ ] Add support for configuring the indent.