### PR TITLE
pkgdev mask: Extend comment template, support -b/--bugs

### DIFF
--- a/src/pkgdev/scripts/pkgdev_mask.py
+++ b/src/pkgdev/scripts/pkgdev_mask.py
@@ -3,6 +3,7 @@ import re
 import shlex
 import subprocess
 import tempfile
+import textwrap
 from collections import deque
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
@@ -168,7 +169,24 @@ class MaskFile:
 def get_comment():
     """Spawn editor to get mask comment."""
     tmp = tempfile.NamedTemporaryFile(mode='w')
-    tmp.write("\n\n# Please enter the mask message. Lines starting with '#' will be ignored.\n")
+    tmp.write(textwrap.dedent("""
+
+        # Please enter the mask message. Lines starting with '#' will be ignored.
+        #
+        # - Best last rites (removal) practices -
+        #
+        # Include the following info:
+        # a) reason for masking
+        # b) bug # for the removal (and yes you should have one)
+        # c) date of removal (either the date or "in x days")
+        #
+        # Example:
+        #
+        # Masked for removal in 30 days.  Doesn't work
+        # with new libfoo. Upstream dead, gtk-1, smells
+        # funny.
+        # Bug #987654
+    """))
     tmp.flush()
 
     editor = shlex.split(os.environ.get('VISUAL', os.environ.get('EDITOR', 'nano')))

--- a/tests/scripts/test_pkgdev_mask.py
+++ b/tests/scripts/test_pkgdev_mask.py
@@ -182,18 +182,20 @@ class TestPkgdevMask:
         assert self.profile.masks == frozenset([atom_cls('cat/masked'), atom_cls('=cat/pkg-0')])
 
     def test_last_rites(self):
-        with os_environ(EDITOR="sed -i '1s/$/mask comment/'"), \
-                patch('sys.argv', self.args + ['cat/pkg', '-r']), \
-                pytest.raises(SystemExit), \
-                chdir(pjoin(self.repo.path)):
-            self.script()
-
         removal_date = self.today + timedelta(days=30)
         today = self.today.strftime('%Y-%m-%d')
         removal = removal_date.strftime('%Y-%m-%d')
-        assert self.masks_path.read_text() == textwrap.dedent(f"""\
-            # First Last <first.last@email.com> ({today})
-            # mask comment
-            # Removal: {removal}
-            cat/pkg
-        """)
+        for rflag in ('-r', '--rites'):
+            with os_environ(EDITOR="sed -i '1s/$/mask comment/'"), \
+                    patch('sys.argv', self.args + ['cat/pkg', rflag]), \
+                    pytest.raises(SystemExit), \
+                    chdir(pjoin(self.repo.path)):
+                self.script()
+
+            assert self.masks_path.read_text() == textwrap.dedent(f"""\
+                # First Last <first.last@email.com> ({today})
+                # mask comment
+                # Removal: {removal}
+                cat/pkg
+            """)
+            self.masks_path.write_text("")  # Reset the contents of package.mask


### PR DESCRIPTION
A two-in-one :-) I'll extend the test cases as well.

---

**pkgdev mask: Extend mask comment template**

To aid developers in writing comments for package.mask, extend the
comment in the temporary file to include example comments.

This is copied straight from the profiles/package.mask file in ::gentoo,
except I've left out the author line and the actual mask line (those are
added automatically).

---
**pkgdev mask: Accept -b/--bug for referencing bugs**

When masking a package - and especially last-riting - the author should
provide bug references. When --bug is given, the comment template is
expanded to include the bug refs.