### PR TITLE
pkgdev mask: offer to send email to gentoo-dev ML

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,6 +64,7 @@ jobs:
         pytest --cov --cov-report=term --cov-report=xml -v
 
     - name: Submit code coverage to codecov
+      if: ${{ matrix.os == 'ubuntu-latest' }}
       uses: codecov/codecov-action@v1
       with:
         file: ./coverage.xml

--- a/completion/bash/pkgdev
+++ b/completion/bash/pkgdev
@@ -113,10 +113,12 @@ _pkgdev() {
         mask)
             subcmd_options="
                 -r --rites
+                -b --bugs
+                --email
             "
 
             case "${prev}" in
-                -r | --rites)
+                -[rb] | --rites | --bugs)
                     COMPREPLY=()
                     ;;
                 *)

--- a/completion/zsh/_pkgdev
+++ b/completion/zsh/_pkgdev
@@ -65,6 +65,8 @@ case $state in
         _arguments -C -A '-*' \
           $base_options \
           {'(--rites)-r','(-r)--rites'}'[mark for last rites]' \
+          {'(--bugs)-b','(-b)--bugs'}'[reference bug in the mask comment]' \
+          '--email[spawn email composer with prepared email for sending to mailing lists]' \
           && ret=0
         ;;
       (push)


### PR DESCRIPTION
Resolves: https://github.com/pkgcore/pkgdev/issues/36

- Works only if we are in last rite mode.
- Uses `xdg-email`, which should work quite nicely spawning user's preferred email composer. User can override using `MAILER` environment variable.
- Sends mainly to `gentoo-dev-announce@lists.gentoo.org`, with CC of `gentoo-dev@lists.gentoo.org`, with body the same as that went to mask file.
- It does NOT add Reply-to field for the email, because `xdg-email` doesn't support it, various clients don't support it from `mailto` url, and also I think this will be nice as to force some manual "confirmation" like from user.
- The generated message, title, format, etc' looks the same as the messages currently sent on `gentoo-dev`, as I didn't want compromises here :)

---

- Please review the `help` and `doc` fields in `pkgdev_mask.py` that it was written fine enough.
- Is there a better argument name - I'm open for suggestions :)