### PR TITLE
pkgdev manifest: add --if-modified

### DIFF
--- a/completion/bash/pkgdev
+++ b/completion/bash/pkgdev
@@ -98,6 +98,7 @@ _pkgdev() {
                 -f --force
                 -m --mirrors
                 -d --distdir
+                --if-modified
             "
 
             case "${prev}" in

--- a/completion/zsh/_pkgdev
+++ b/completion/zsh/_pkgdev
@@ -59,6 +59,7 @@ case $state in
           {'(--distdir)-d','(-d)--distdir'}'[target download directory]:distdir:_files -/' \
           {'(--force)-f','(-f)--force'}'[forcibly remanifest packages]' \
           {'(--mirrors)-m','(-m)--mirrors'}'[enable fetching from Gentoo mirrors]' \
+          '--if-modified[only check packages that have uncommitted modifications]' \
           && ret=0
         ;;
       (mask)


### PR DESCRIPTION
Restrict targets for manifest to only targets that have uncommitted modifications.
The short help message was copied from `repoman`, but the longer one was written by me, so please check it more thoroughly.