### PR TITLE
pkgdev commit: make sign-off off by default

### DIFF
--- a/doc/man/config.rst
+++ b/doc/man/config.rst
@@ -33,6 +33,11 @@ related values. To find all possible configuration options, run:
     [gentoo]
     push.ask = true
 
+- Sign off all commits for the 'gentoo' repository::
+
+    [gentoo]
+    push.signoff = true
+
 - When committing, stage all files in current working directory (note that this
   option doesn't expect value, therefore no value is defined post equal sign)::
 

--- a/src/pkgdev/scripts/pkgdev_commit.py
+++ b/src/pkgdev/scripts/pkgdev_commit.py
@@ -43,6 +43,8 @@ class ArgumentParser(cli.ArgumentParser):
             args.append('--dry-run')
         if namespace.verbosity:
             args.append('-v')
+        if namespace.signoff:
+            args.append('--signoff')
         namespace.commit_args = args
         return namespace, []
 
@@ -119,6 +121,17 @@ commit_opts.add_argument(
 
         This is performed by default for the gentoo repo, but can be forcibly
         disabled or enabled as required.
+    """)
+commit_opts.add_argument(
+    '--signoff', nargs='?', const=True, action=arghparse.StoreBool,
+    help='Add a Signed-off-by at the end of the commit log message',
+    docs="""
+        Add a Signed-off-by trailer by the committer at the end of the commit
+        log message.
+
+        For commiting to the Gentoo repository, under GLEP-76, the commiter
+        shall certify agreement to the Certificate of Origin by adding
+        Signed-off-by line containing the committer's legal name.
     """)
 
 msg_actions = commit_opts.add_mutually_exclusive_group()
@@ -721,9 +734,8 @@ def _commit_validate(parser, namespace):
         namespace.scan_args.extend(shlex.split(namespace.pkgcheck_scan))
     namespace.scan_args.extend(['--exit', 'GentooCI', '--staged'])
 
-    # assume signed commits means also requiring signoffs
     if namespace.repo.config.sign_commits:
-        namespace.commit_args.extend(['--signoff', '--gpg-sign'])
+        namespace.commit_args.append('--gpg-sign')
 
 
 def update_manifests(options, out, err, changes):

--- a/tests/scripts/test_pkgdev_commit.py
+++ b/tests/scripts/test_pkgdev_commit.py
@@ -58,11 +58,19 @@ class TestPkgdevCommitParseArgs:
             options, _ = tool.parse_args(['commit', '-u'])
             assert '--signoff' not in options.commit_args
             assert '--gpg-sign' not in options.commit_args
+
+            options, _ = tool.parse_args(['commit', '-u', '--signoff'])
+            assert '--signoff' in options.commit_args
+            assert '--gpg-sign' not in options.commit_args
         # signed commits enabled by layout.conf setting
         with open(pjoin(git_repo.path, 'metadata/layout.conf'), 'a+') as f:
             f.write('sign-commits = true\n')
         with chdir(repo.location):
             options, _ = tool.parse_args(['commit', '-u'])
+            assert '--signoff' not in options.commit_args
+            assert '--gpg-sign' in options.commit_args
+
+            options, _ = tool.parse_args(['commit', '-u', '--signoff'])
             assert '--signoff' in options.commit_args
             assert '--gpg-sign' in options.commit_args
 


### PR DESCRIPTION
Make sign-off off by default, and enable the user to pass if manually
using `--signoff`, or by setting `commit.signoff` in config file.

Signed-off-by: Arthur Zamarin <arthurzam@gentoo.org>