### PR TITLE
push: add option `--pull`

### DIFF
--- a/data/share/bash-completion/completions/pkgdev
+++ b/data/share/bash-completion/completions/pkgdev
@@ -134,6 +134,7 @@ _pkgdev() {
             subcmd_options="
                 -A --ask
                 -n --dry-run
+                --pull
             "
 
             COMPREPLY+=($(compgen -W "${subcmd_options}" -- "${cur}"))

--- a/data/share/zsh/site-functions/_pkgdev
+++ b/data/share/zsh/site-functions/_pkgdev
@@ -77,6 +77,7 @@ case $state in
           $base_options \
           {'(--ask)-A','(-A)--ask'}'[confirm pushing commits with QA errors]' \
           {'(--dry-run)-n','(-n)--dry-run'}'[pretend to push commits]' \
+          '--pull[run git pull --rebase before scanning]' \
           && ret=0
         ;;
       (showkw)

--- a/src/pkgdev/scripts/pkgdev_push.py
+++ b/src/pkgdev/scripts/pkgdev_push.py
@@ -32,6 +32,9 @@ push_opts.add_argument(
 push_opts.add_argument(
     '-n', '--dry-run', action='store_true',
     help='pretend to push the commits')
+push_opts.add_argument(
+    '--pull', action='store_true',
+    help='run `git pull --rebase` before scanning')
 
 
 @push.bind_final_check
@@ -45,6 +48,9 @@ def _commit_validate(parser, namespace):
 
 @push.bind_main_func
 def _push(options, out, err):
+    if options.pull:
+        git.run('pull', '--rebase', cwd=options.repo.location)
+
     # scan commits for QA issues
     pipe = scan(options.scan_args)
     with reporters.FancyReporter(out) as reporter:


### PR DESCRIPTION
Add a new option `--pull` to `pkgdev push` to pull all changes before starting the scan & push. This is very useful for most normal usage for developers.

This can be also set in config, but adding the line:
```
push.pull =
```

Resolves: https://github.com/pkgcore/pkgdev/issues/102