### PR TITLE
pkgdev bugs: Fix spelling of agent noun for 'file'

### DIFF
--- a/src/pkgdev/scripts/pkgdev_bugs.py
+++ b/src/pkgdev/scripts/pkgdev_bugs.py
@@ -1,4 +1,4 @@
-"""Automatic bugs filler"""
+"""Automatic bugs filer"""
 
 import json
 import urllib.request as urllib


### PR DESCRIPTION
The agent noun of the verb '(to) file' is 'filer'.
Signed-off-by: Arsen Arsenović <arsen@gentoo.org>

thanks, this is a very handy tool