### PR TITLE
commit: add support to enable/disable gpg signing

### DIFF
--- a/data/share/bash-completion/completions/pkgdev
+++ b/data/share/bash-completion/completions/pkgdev
@@ -75,6 +75,7 @@ _pkgdev() {
                 -A --ask
                 --mangle
                 --signoff
+                --gpg-sign --no-gpg-sign
                 -m --message
                 -M --message-template
                 -e --edit

--- a/data/share/zsh/site-functions/_pkgdev
+++ b/data/share/zsh/site-functions/_pkgdev
@@ -48,6 +48,8 @@ case $state in
           {'(--ask)-A','(-A)--ask'}'[confirm creating commit with QA errors]' \
           '--mangle[forcibly enable/disable file mangling]' \
           '--signoff[add a Signed-off-by trailer]' \
+          '--gpg-sign[enable GPG signing]' \
+          '--no-gpg-sign[disable GPG signing]' \
           \*{--message,-m}'[specify commit message]:message' \
           {'(--message-template)-M','(-M)--message-template'}'[use commit message template from specified file]:template:_files' \
           {'(--edit)-e','(-e)--edit'}'[force edit of commit]' \

--- a/src/pkgdev/scripts/pkgdev_commit.py
+++ b/src/pkgdev/scripts/pkgdev_commit.py
@@ -162,6 +162,16 @@ commit_opts.add_argument(
     """,
 )
 commit_opts.add_argument(
+    "--gpg-sign",
+    action=argparse.BooleanOptionalAction,
+    help="GPG-sign commit",
+    docs="""
+        Pass ``--gpg-sign`` or ``--no-gpg-sign`` to the ``git commit`` command.
+        This option enables to override the default behavior or the behavior
+        defined by ``sign-commits = true`` in ``metadata/layout.conf`` file.
+    """,
+)
+commit_opts.add_argument(
     "-d",
     "--distdir",
     type=arghparse.create_dir,
@@ -832,7 +842,9 @@ def _commit_validate(parser, namespace):
         namespace.scan_args.extend(shlex.split(namespace.pkgcheck_scan))
     namespace.scan_args.extend(["--exit", "GentooCI", "--staged"])
 
-    if namespace.repo.config.sign_commits:
+    if namespace.gpg_sign is False:
+        namespace.commit_args.append("--no-gpg-sign")
+    elif namespace.gpg_sign is True or namespace.repo.config.sign_commits:
         namespace.commit_args.append("--gpg-sign")
 
 

--- a/tests/scripts/test_pkgdev_commit.py
+++ b/tests/scripts/test_pkgdev_commit.py
@@ -58,6 +58,15 @@ class TestPkgdevCommitParseArgs:
             options, _ = tool.parse_args(["commit", "-u", "--signoff"])
             assert "--signoff" in options.commit_args
             assert "--gpg-sign" not in options.commit_args
+        # enable using specific argument
+        with chdir(repo.location):
+            options, _ = tool.parse_args(["commit", "-u", "--gpg-sign"])
+            assert "--signoff" not in options.commit_args
+            assert "--gpg-sign" in options.commit_args
+
+            options, _ = tool.parse_args(["commit", "-u", "--signoff", "--gpg-sign"])
+            assert "--signoff" in options.commit_args
+            assert "--gpg-sign" in options.commit_args
         # signed commits enabled by layout.conf setting
         with open(pjoin(git_repo.path, "metadata/layout.conf"), "a+") as f:
             f.write("sign-commits = true\n")
@@ -69,6 +78,15 @@ class TestPkgdevCommitParseArgs:
             options, _ = tool.parse_args(["commit", "-u", "--signoff"])
             assert "--signoff" in options.commit_args
             assert "--gpg-sign" in options.commit_args
+        # disable using specific argument
+        with chdir(repo.location):
+            options, _ = tool.parse_args(["commit", "-u", "--no-gpg-sign"])
+            assert "--signoff" not in options.commit_args
+            assert "--gpg-sign" not in options.commit_args
+
+            options, _ = tool.parse_args(["commit", "-u", "--signoff", "--no-gpg-sign"])
+            assert "--signoff" in options.commit_args
+            assert "--gpg-sign" not in options.commit_args
 
     def test_git_commit_args(self, repo, make_git_repo, tool):
         git_repo = make_git_repo(repo.location)


### PR DESCRIPTION
You can use "--gpg-sign" and "--no-gpg-sign" to enable/disable gpg signing. If you don't specify any of them, pkgdev will use the value listed in metadata/layout.conf.

You can also set this in configuration, using `commit.no-gpg-sign=` or `commit.gpg-sign=`.

Resolves: https://github.com/pkgcore/pkgdev/issues/146