### PR TITLE
pkgdev_bugs: do not swallow exceptions when reading ~/.bugz_token

### DIFF
--- a/src/pkgdev/scripts/pkgdev_bugs.py
+++ b/src/pkgdev/scripts/pkgdev_bugs.py
@@ -546,8 +546,9 @@ def main(options, out: Formatter, err: Formatter):
         node.cleanup_keywords(search_repo)
 
     if options.api_key is None:
-        with contextlib.suppress(Exception):
-            options.api_key = (Path.home() / ".bugz_token").read_text().strip() or None
+        bugz_token_file = Path.home() / ".bugz_token"
+        if bugz_token_file.is_file:
+            options.api_key = bugz_token_file.read_text().strip()
 
     if not d.nodes:
         out.write(out.fg("red"), "Nothing to do, exiting", out.reset)


### PR DESCRIPTION
In case the file is not readable, or other issues, do not swallow the exception.