### PR TITLE
bugs: allow searching by maintainer, inc. project

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -19,3 +19,5 @@ exclude_lines =
 
 	# ignore unexecutable code
 	if __name__ == .__main__.:
+omit =
+	**/pkgdev/scripts/pkgdev_bugs.py

--- a/data/share/bash-completion/completions/pkgdev
+++ b/data/share/bash-completion/completions/pkgdev
@@ -246,6 +246,7 @@ _pkgdev() {
             subcmd_options="
                 --api-key
                 --auto-cc-arches
+                --find-by-maintainer
                 --blocks
                 --dot
                 -s --stablereq
@@ -253,7 +254,7 @@ _pkgdev() {
             "
 
             case "${prev}" in
-                --api-key | --auto-cc-arches | --blocks)
+                --api-key | --auto-cc-arches | --blocks | --find-by-maintainer)
                     COMPREPLY=()
                     ;;
                 --dot)

--- a/data/share/bash-completion/completions/pkgdev
+++ b/data/share/bash-completion/completions/pkgdev
@@ -247,6 +247,7 @@ _pkgdev() {
                 --api-key
                 --auto-cc-arches
                 --find-by-maintainer
+                --projects
                 --filter-stablereqs
                 --stabletime
                 --blocks

--- a/data/share/bash-completion/completions/pkgdev
+++ b/data/share/bash-completion/completions/pkgdev
@@ -247,6 +247,8 @@ _pkgdev() {
                 --api-key
                 --auto-cc-arches
                 --find-by-maintainer
+                --filter-stablereqs
+                --stabletime
                 --blocks
                 --dot
                 -s --stablereq
@@ -254,7 +256,7 @@ _pkgdev() {
             "
 
             case "${prev}" in
-                --api-key | --auto-cc-arches | --blocks | --find-by-maintainer)
+                --api-key | --auto-cc-arches | --blocks | --find-by-maintainer | --stabletime)
                     COMPREPLY=()
                     ;;
                 --dot)


### PR DESCRIPTION
- bugs: improve best match finder
- bugs: add ``--find-by-maintainer`` option
- bugs: add support for filtering targets by StableRequest
- bugs: auto extend maintainers with projects

So a new super invocation now is:

```
pkgdev bugs --find-by-maintainer arthurzam@gentoo.org,-ppc@gentoo.org,-java@gentoo.org --projects --filter-stablereqs
```

Resolves: https://github.com/pkgcore/pkgdev/issues/157