### PR TITLE
docs: fix intersphinx and add automatic maintenance

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -324,3 +324,10 @@ epub_exclude_files = ["search.html"]
 
 # If false, no index is generated.
 # epub_use_index = True
+
+intersphinx_mapping = {
+    "python": ("https://docs.python.org/3", None),
+}
+intersphinx_mapping.update(
+    (x, (f"https://pkgcore.github.io/{x}", None)) for x in "pkgcheck pkgcore snakeoil".split()
+)

--- a/doc/man/pkgdev
+++ b/doc/man/pkgdev
@@ -1,1 +1,0 @@
-/home/arthur/src/pkgcore/pkgdev/doc/generated/pkgdev


### PR DESCRIPTION
Without this sphinx won't do the necessary linkage for documentation references back into these projects.

See https://github.com/pkgcore/pkgcore/actions/runs/7656999844/job/20874145430 for what kicked all of this off.  I've not checked pkgdev docs to see if this linkage is explicitly used, but the sphinx module *is* used, thus adding this.