### PR TITLE
mask: support auto filing of last-rite bug & PMASKED bugs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
             experimental: true
           - os: macos-latest
             python-version: '3.11'
-            experimental: false
+            experimental: true
       fail-fast: false
 
     steps:

--- a/data/share/bash-completion/completions/pkgdev
+++ b/data/share/bash-completion/completions/pkgdev
@@ -121,10 +121,12 @@ _pkgdev() {
                 -r --rites
                 -b --bug
                 --email
+                --api-key
+                --file-bug
             "
 
             case "${prev}" in
-                -[rb] | --rites | --bugs)
+                -[rb] | --rites | --bugs | --api-key)
                     COMPREPLY=()
                     ;;
                 *)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
 	"flit_core >=3.8,<4",
-	"snakeoil ~=0.10.5",
+	"snakeoil ~=0.10.8",
 ]
 build-backend = "py_build"
 backend-path = ["."]
@@ -27,9 +27,9 @@ classifiers = [
 dynamic = ["version"]
 
 dependencies = [
-	"snakeoil~=0.10.5",
+	"snakeoil~=0.10.8",
 	"pkgcore~=0.12.23",
-	"pkgcheck~=0.10.25",
+	"pkgcheck~=0.10.30",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
And my newest hat trick, auto filing of last-rite bugs. I was getting fed up with all the `lr-file-bug` calls during the EAPI=6 cleanup, passing all the args correctly in the form, and then copying everything back to `pkgdev mask` invocation. So since I'm that comfortable with filing bugs using `pkgdev bugs`, why not import it into `pkgdev mask`?

1. File a new bug, CC treecleaners, auto assign to all maintainers, add blocks on reference bugs.
2. Add PMASKED keyword to all referenced bugs.
3. Continue as usual.