### PR TITLE
Add support for Closes tags with custom Bugzilla resolution

### DIFF
--- a/data/share/bash-completion/completions/pkgdev
+++ b/data/share/bash-completion/completions/pkgdev
@@ -4,7 +4,7 @@ source "/usr/share/bash-completion/helpers/gentoo-common.sh"
 
 _pkgdev() {
     local i=1 cmd cur prev words cword split
-    _init_completion -n : || return
+    _comp_initialize -n : "$@" || return
 
     local subcommands="
         bugs

--- a/data/share/bash-completion/completions/pkgdev
+++ b/data/share/bash-completion/completions/pkgdev
@@ -4,7 +4,7 @@ source "/usr/share/bash-completion/helpers/gentoo-common.sh"
 
 _pkgdev() {
     local i=1 cmd cur prev words cword split
-    _init_completion || return
+    _init_completion -n : || return
 
     local subcommands="
         bugs
@@ -79,7 +79,23 @@ _pkgdev() {
             "
 
             case "${prev}" in
-                -[bcTm] | --bug | --closes | --tag | --message)
+                -c | --closes)
+                    local resolutions=(
+                        fixed
+                        obsolete
+                        pkgremoved
+                    )
+
+                    local bug="${cur%:*}"
+                    if [[ ${bug} != ${cur} && ${bug} != http?(s) ]]; then
+                        local bugres="${resolutions[*]/#/${bug}:}"
+                        COMPREPLY=($(compgen -W "${bugres}" -- "${cur}"))
+                        _comp_ltrim_colon_completions "$cur"
+                    else
+                        COMPREPLY=()
+                    fi
+                    ;;
+                -[bTm] | --bug | --tag | --message)
                     COMPREPLY=()
                     ;;
                 -M | --message-template)


### PR DESCRIPTION
This PR is part of a larger effort[1] to automate resolving bugs on Gentoo's Bugzilla with the correct resolutions.
The command line syntax would be:
* `<bug>:<resolution>` for a given bgo bug with an explicit resolution
* `<bug>:` or `<bug>` for any bug without a resolution (implicitly `FIXED` for a bgo bug)

Apart from `FIXED`, I chose to support:
* `OBSOLETE` e.g. for when older versions of a package get dropped which implicitly fixes a bug
* `PKGREMOVED` to encourage its adoption for the removal of packages

If you think any resolutions are missing here, please tell me!

I wasn't sure how to handle malformed URL-like input with multiple colons like `https://foo:bar:obsolete`. Currently, it gets converted into a `Closes: https://foo:bar (obsolete)` tag, similar to how `-T/--tag` does it.

---
[1]: Patch for infra's githooks: https://bugs.gentoo.org/934825