### PR TITLE
Add a new `pkgdev commit` mangle to remove stable keywords

### DIFF
--- a/src/pkgdev/mangle.py
+++ b/src/pkgdev/mangle.py
@@ -84,7 +84,15 @@ class Mangler:
                 kws = sorted(mo.group("keywords").split(), key=keywords_sort_key)
                 # Only remove stable keywords on new ebuild creations
                 # For our purposes, renames are also new ebuild creations
-                if change.status in ("A", "R"):
+                print(change.atom.version)
+                # print(change.atom.revision)
+                if change.status == "A":
+                    kws = keywords_remove_stable(kws)
+                if (
+                    change.status == "R"
+                    and change.old is not None
+                    and change.old.version != change.atom.version
+                ):
                     kws = keywords_remove_stable(kws)
                 new_kw = " ".join(kws)
                 if not mo.group("quote"):


### PR DESCRIPTION
One of the most common maintenance tasks in the tree is a simple version bump. With this mangle, `pkgdev commit` can automatically remove the stable keyword from ebuilds copied from a prior version.

This should reduce contributor mistakes, and save developers time on both code review and manually editing keywords for their commits.