### PR TITLE
use a fake $HOME for tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,13 +1,35 @@
+import os
+import shutil
+import tempfile
+
 import pytest
+from snakeoil.cli import arghparse
+
 from pkgdev.cli import Tool
 from pkgdev.scripts import pkgdev
-from snakeoil.cli import arghparse
 
 pytest_plugins = ["pkgcore"]
 
 
 @pytest.fixture(scope="session")
-def tool():
+def temporary_home():
+    """Generate a temporary directory and set$HOME to it."""
+    old_home = os.environ.get("HOME")
+    new_home = None
+    try:
+        new_home = tempfile.mkdtemp()
+        os.environ["HOME"] = new_home
+        yield
+    finally:
+        if old_home is None:
+            del os.environ["HOME"]
+        else:
+            os.environ["HOME"] = old_home
+            shutil.rmtree(new_home)  # pyright: ignore[reportArgumentType]
+
+
+@pytest.fixture(scope="session")
+def tool(temporary_home):
     """Generate a tool utility for running pkgdev."""
     return Tool(pkgdev.argparser)
 


### PR DESCRIPTION
git uses both repo/.git/config and $HOME/.gitconfig, thus the tests have been picking up my commit.gpgsign=1 .  Whilst pkgcore's git repo fixture can be tweaked to add that suppression, hygenically it's better to disconnect the users personal configuration from tests in full.

TL;dr: this stops tests from popping a gpg key decrypt randomly for my local dev.